### PR TITLE
feature/Homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 /public/assets/
 /assets/vendor/
 ###< symfony/asset-mapper ###
+
+/.idea

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,3 +1,0 @@
-body {
-    background-color: skyblue;
-}

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class HomeController extends AbstractController
+{
+    #[Route('/', name: 'app_home')]
+    public function index(): Response
+    {
+        return $this->render('home/index.html.twig', [
+            'controller_name' => 'HomeController',
+        ]);
+    }
+}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -1,0 +1,20 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Hello HomeController!{% endblock %}
+
+{% block body %}
+<style>
+    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
+    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
+</style>
+
+<div class="example-wrapper">
+    <h1>Hello {{ controller_name }}! ✅</h1>
+
+    This friendly message is coming from:
+    <ul>
+        <li>Your controller at <code>/Users/mathieulp/Desktop/AltumWeb/AltumWeb-Docker/www/FinTrack/src/Controller/HomeController.php</code></li>
+        <li>Your template at <code>/Users/mathieulp/Desktop/AltumWeb/AltumWeb-Docker/www/FinTrack/templates/home/index.html.twig</code></li>
+    </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
This pull request introduces a new `HomeController` in the `src/Controller` directory, sets up a corresponding template in the `templates/home` directory, and removes a specific background color style from the global CSS.

New HomeController setup:

* [`src/Controller/HomeController.php`](diffhunk://#diff-cf8ddd8abc8d002c914ecaae76ad52cf5fea1a58eae9d998ba252d0b804b80e6R1-R18): Added a new `HomeController` class with a route for the home page and a method to render the `home/index.html.twig` template.

Template setup:

* [`templates/home/index.html.twig`](diffhunk://#diff-4bedfb7c3877c5346f5fbe69bfc7d816534bb5cdb093cb4be16084750f0cb09dR1-R20): Created a new template extending `base.html.twig`, with blocks for title and body, including a friendly message and style definitions.

CSS changes:

* [`assets/styles/app.css`](diffhunk://#diff-9c7074d59a09b080225d7341bd2320aa540d673e7d771a9c973f5811d6b2e41bL1-L3): Removed the background color style for the `body` element.